### PR TITLE
Implement weighted lru cache semantic (take 2)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,7 @@ impl<K, V, S: BuildHasher, W: WeightScale<K, V>> CLruCacheConfig<K, V, S, W> {
         }
     }
 
-    /// Configure the amount of pre-allocated memory to order to hold at least `reserve` elements
+    /// Configure the amount of pre-allocated memory in order to hold at least `reserve` elements
     /// without reallocating.
     pub fn with_memory(mut self, reserve: usize) -> Self {
         self.reserve = Some(reserve);

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,15 +5,15 @@ use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 
 /// A configuration structure used to create an LRU cache.
-pub struct CLruCacheConfig<V, S = RandomState, W = ZeroWeightScale> {
+pub struct CLruCacheConfig<K, V, S = RandomState, W = ZeroWeightScale> {
     pub(crate) capacity: NonZeroUsize,
     pub(crate) hash_builder: S,
     pub(crate) reserve: Option<usize>,
     pub(crate) scale: W,
-    _marker: PhantomData<V>,
+    _marker: PhantomData<(K, V)>,
 }
 
-impl<V> CLruCacheConfig<V> {
+impl<K, V> CLruCacheConfig<K, V> {
     /// Creates a new configuration that will create an LRU cache
     /// that will hold at most `capacity` elements and default parameters.
     pub fn new(capacity: NonZeroUsize) -> Self {
@@ -27,9 +27,9 @@ impl<V> CLruCacheConfig<V> {
     }
 }
 
-impl<V, S: BuildHasher, W: WeightScale<V>> CLruCacheConfig<V, S, W> {
+impl<K, V, S: BuildHasher, W: WeightScale<K, V>> CLruCacheConfig<K, V, S, W> {
     /// Configure the provided hash builder.
-    pub fn with_hasher<O: BuildHasher>(self, hash_builder: O) -> CLruCacheConfig<V, O, W> {
+    pub fn with_hasher<O: BuildHasher>(self, hash_builder: O) -> CLruCacheConfig<K, V, O, W> {
         let Self {
             capacity,
             reserve,
@@ -54,7 +54,7 @@ impl<V, S: BuildHasher, W: WeightScale<V>> CLruCacheConfig<V, S, W> {
     }
 
     /// Configure the provided scale.
-    pub fn with_scale<O: WeightScale<V>>(self, scale: O) -> CLruCacheConfig<V, S, O> {
+    pub fn with_scale<O: WeightScale<K, V>>(self, scale: O) -> CLruCacheConfig<K, V, S, O> {
         let Self {
             capacity,
             hash_builder,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,72 @@
+use crate::weight::{WeightScale, ZeroWeightScale};
+use std::collections::hash_map::RandomState;
+use std::hash::BuildHasher;
+use std::marker::PhantomData;
+use std::num::NonZeroUsize;
+
+/// A configuration structure used to create an LRU cache.
+pub struct CLruCacheConfig<V, S = RandomState, W = ZeroWeightScale> {
+    pub(crate) capacity: NonZeroUsize,
+    pub(crate) hash_builder: S,
+    pub(crate) reserve: Option<usize>,
+    pub(crate) scale: W,
+    _marker: PhantomData<V>,
+}
+
+impl<V> CLruCacheConfig<V> {
+    /// Creates a new configuration that will create an LRU cache
+    /// that will hold at most `capacity` elements and default parameters.
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            capacity,
+            hash_builder: RandomState::default(),
+            reserve: None,
+            scale: ZeroWeightScale,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<V, S: BuildHasher, W: WeightScale<V>> CLruCacheConfig<V, S, W> {
+    /// Configure the provided hash builder.
+    pub fn with_hasher<O: BuildHasher>(self, hash_builder: O) -> CLruCacheConfig<V, O, W> {
+        let Self {
+            capacity,
+            reserve,
+            scale,
+            _marker,
+            ..
+        } = self;
+        CLruCacheConfig {
+            capacity,
+            hash_builder,
+            reserve,
+            scale,
+            _marker,
+        }
+    }
+
+    /// Configure the amount of pre-allocated memory to order to hold at least `reserve` elements
+    /// without reallocating.
+    pub fn with_memory(mut self, reserve: usize) -> Self {
+        self.reserve = Some(reserve);
+        self
+    }
+
+    /// Configure the provided scale.
+    pub fn with_scale<O: WeightScale<V>>(self, scale: O) -> CLruCacheConfig<V, S, O> {
+        let Self {
+            capacity,
+            hash_builder,
+            reserve,
+            ..
+        } = self;
+        CLruCacheConfig {
+            capacity,
+            hash_builder,
+            reserve,
+            scale,
+            _marker: PhantomData,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -626,7 +626,10 @@ impl<K: Eq + Hash, V, S: BuildHasher, W: WeightScale<K, V>> CLruCache<K, V, S, W
             .map(|CLruNode { key, value }| (key.as_ref(), value))
     }
 
-    /// Puts a key-value pair into cache.
+    /// Puts a key-value pair into cache taking it's weight into account.
+    /// If the weight of the new element is greater than what the cache can hold,
+    /// it returns the provided key-value pair as an error.
+    /// Otherwise, it removes enough elements for the new element to be inserted.
     /// If the key already exists in the cache, then it updates the key's value and returns the old value.
     /// Otherwise, `None` is returned.
     pub fn put_with_weight(&mut self, key: K, value: V) -> Result<Option<V>, (K, V)> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,8 +438,14 @@ impl<'a, T> ExactSizeIterator for FixedSizeListIterMut<'a, T> {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Debug, Eq, Hash, PartialEq)]
 struct Key<K>(Rc<K>);
+
+impl<K> Clone for Key<K> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 
 impl<K> AsRef<K> for Key<K> {
     fn as_ref(&self) -> &K {
@@ -645,7 +651,7 @@ impl<K: Eq + Hash, V, S: BuildHasher, W: WeightScale<K, V>> CLruCache<K, V, S, W
                 let (idx, _) = self
                     .storage
                     .push_front(CLruNode {
-                        key: Key(occ.key().0.clone()),
+                        key: occ.key().clone(),
                         value,
                     })
                     .unwrap();
@@ -669,7 +675,7 @@ impl<K: Eq + Hash, V, S: BuildHasher, W: WeightScale<K, V>> CLruCache<K, V, S, W
                 let (idx, _) = self
                     .storage
                     .push_front(CLruNode {
-                        key: Key(vac.key().0.clone()),
+                        key: vac.key().clone(),
                         value,
                     })
                     .unwrap();
@@ -833,7 +839,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, _) = self
                     .storage
                     .push_front(CLruNode {
-                        key: Key(occ.key().0.clone()),
+                        key: occ.key().clone(),
                         value,
                     })
                     .unwrap();
@@ -851,7 +857,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, _) = self
                     .storage
                     .push_front(CLruNode {
-                        key: Key(vac.key().0.clone()),
+                        key: vac.key().clone(),
                         value,
                     })
                     .unwrap();
@@ -888,7 +894,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, node) = self
                     .storage
                     .push_front(CLruNode {
-                        key: Key(occ.key().0.clone()),
+                        key: occ.key().clone(),
                         value: node.value,
                     })
                     .unwrap();
@@ -908,7 +914,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, node) = self
                     .storage
                     .push_front(CLruNode {
-                        key: Key(vac.key().0.clone()),
+                        key: vac.key().clone(),
                         value,
                     })
                     .unwrap();
@@ -952,7 +958,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, node) = self
                     .storage
                     .push_front(CLruNode {
-                        key: Key(occ.key().0.clone()),
+                        key: occ.key().clone(),
                         value: node.value,
                     })
                     .unwrap();
@@ -977,7 +983,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, node) = self
                     .storage
                     .push_front(CLruNode {
-                        key: Key(vac.key().0.clone()),
+                        key: vac.key().clone(),
                         value,
                     })
                     .unwrap();

--- a/src/weight.rs
+++ b/src/weight.rs
@@ -1,0 +1,16 @@
+/// Trait used to retrieve the weight of a value.
+pub trait WeightScale<V> {
+    /// Returns the weight of a value.
+    fn weight(&self, value: &V) -> usize;
+}
+
+/// A scale that always return 0.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ZeroWeightScale;
+
+impl<V> WeightScale<V> for ZeroWeightScale {
+    #[inline]
+    fn weight(&self, _: &V) -> usize {
+        0
+    }
+}

--- a/src/weight.rs
+++ b/src/weight.rs
@@ -1,6 +1,6 @@
-/// Trait used to retrieve the weight of a value.
+/// Trait used to retrieve the weight of a key-value pair.
 pub trait WeightScale<K, V> {
-    /// Returns the weight of a value.
+    /// Returns the weight of a key-value pair.
     fn weight(&self, key: &K, value: &V) -> usize;
 }
 

--- a/src/weight.rs
+++ b/src/weight.rs
@@ -1,16 +1,16 @@
 /// Trait used to retrieve the weight of a value.
-pub trait WeightScale<V> {
+pub trait WeightScale<K, V> {
     /// Returns the weight of a value.
-    fn weight(&self, value: &V) -> usize;
+    fn weight(&self, key: &K, value: &V) -> usize;
 }
 
 /// A scale that always return 0.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct ZeroWeightScale;
 
-impl<V> WeightScale<V> for ZeroWeightScale {
+impl<K, V> WeightScale<K, V> for ZeroWeightScale {
     #[inline]
-    fn weight(&self, _: &V) -> usize {
+    fn weight(&self, _: &K, _: &V) -> usize {
         0
     }
 }


### PR DESCRIPTION
This proposal introduces the `WeightScale` trait that is used to retrieve the weight of a value.

In addition to the number of elements in the cache, the weight of each element is also counted against the capacity:
```
assert!(cache.len() + cache.weight() <= cache.capacity());
```

This is useful for multiple reasons:

1. It avoids having to store the weight as a `NonZeroUsize` which is quite an unpleasant API to work with. Each value can have a weight computed as a `usize`, which is nice for using types that already have some information that could be used as a weight like `String::len()` etc
2. It does not require to introduce another limit like `max_weight`.

Using a trait also has some advantages in order to keep the cache in a coherent state, although one could see it as a limitation:

* `CLruCache::put` and friends are only implemented for the `ZeroWeightScale` scale which is the default type for the scale and turns the cache into a more classic LRU cache.
* APIs that return a mutable reference to the value of an element are only available for the `ZeroWeightScale` scale since changing the value can lead to a change of its weight.

cc @webmaster128 @maurolacy