### PR TITLE
Manually implement `Send` trait for `CLruCache`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,4 +120,3 @@ This should help catch bugs sooner than later.
 ## TODO
 
 * improve documentation and add examples
-* figure out `Send`/`Sync` traits support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,6 +504,14 @@ impl<'a, T> ExactSizeIterator for FixedSizeListIterMut<'a, T> {
     }
 }
 
+// Internal key structure. The generic type `K` is the user supplied
+// key type that is wrapped into a `Rc` in order to be shared both in
+// the `HashMap` lookup table and in the `FixedSizeList` as well without
+// having to clone the key. The keys need to be stored in the `FixedSizeList`
+// because we sometime need to be able to get key associated with a value
+// to later remove it from the lookup table (see `CLruCache::put`).
+// The `Rc` is fully owned by the cache, and is never surfaced publicly in
+// any API. This invariant is what allows the cache to implement `Send`.
 #[derive(Debug, Eq, Hash, PartialEq)]
 struct Key<K>(Rc<K>);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,12 +352,23 @@ impl<T> FixedSizeList<T> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct FixedSizeListIter<'a, T> {
     list: &'a FixedSizeList<T>,
     front: usize,
     back: usize,
     len: usize,
+}
+
+impl<'a, T> Clone for FixedSizeListIter<'a, T> {
+    fn clone(&self) -> Self {
+        Self {
+            list: self.list,
+            front: self.front,
+            back: self.back,
+            len: self.len,
+        }
+    }
 }
 
 impl<'a, T> Iterator for FixedSizeListIter<'a, T> {
@@ -496,9 +507,9 @@ impl<'a, T> ExactSizeIterator for FixedSizeListIterMut<'a, T> {
 #[derive(Debug, Eq, Hash, PartialEq)]
 struct Key<K>(Rc<K>);
 
-impl<K> Clone for Key<K> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
+impl<K> From<&Key<K>> for Key<K> {
+    fn from(key: &Key<K>) -> Self {
+        Self(key.0.clone())
     }
 }
 
@@ -527,7 +538,7 @@ impl<Q: ?Sized, K: Borrow<Q>> Borrow<KeyRef<Q>> for Key<K> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct CLruNode<K, V> {
     key: Key<K>,
     value: V,
@@ -714,7 +725,7 @@ impl<K: Eq + Hash, V, S: BuildHasher, W: WeightScale<K, V>> CLruCache<K, V, S, W
                 let (idx, _) = self
                     .storage
                     .push_front(CLruNode {
-                        key: occ.key().clone(),
+                        key: occ.key().into(),
                         value,
                     })
                     .unwrap();
@@ -738,7 +749,7 @@ impl<K: Eq + Hash, V, S: BuildHasher, W: WeightScale<K, V>> CLruCache<K, V, S, W
                 let (idx, _) = self
                     .storage
                     .push_front(CLruNode {
-                        key: vac.key().clone(),
+                        key: vac.key().into(),
                         value,
                     })
                     .unwrap();
@@ -902,7 +913,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, _) = self
                     .storage
                     .push_front(CLruNode {
-                        key: occ.key().clone(),
+                        key: occ.key().into(),
                         value,
                     })
                     .unwrap();
@@ -920,7 +931,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, _) = self
                     .storage
                     .push_front(CLruNode {
-                        key: vac.key().clone(),
+                        key: vac.key().into(),
                         value,
                     })
                     .unwrap();
@@ -957,7 +968,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, node) = self
                     .storage
                     .push_front(CLruNode {
-                        key: occ.key().clone(),
+                        key: occ.key().into(),
                         value: node.value,
                     })
                     .unwrap();
@@ -977,7 +988,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, node) = self
                     .storage
                     .push_front(CLruNode {
-                        key: vac.key().clone(),
+                        key: vac.key().into(),
                         value,
                     })
                     .unwrap();
@@ -1021,7 +1032,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, node) = self
                     .storage
                     .push_front(CLruNode {
-                        key: occ.key().clone(),
+                        key: occ.key().into(),
                         value: node.value,
                     })
                     .unwrap();
@@ -1046,7 +1057,7 @@ impl<K: Eq + Hash, V, S: BuildHasher> CLruCache<K, V, S> {
                 let (idx, node) = self
                     .storage
                     .push_front(CLruNode {
-                        key: vac.key().clone(),
+                        key: vac.key().into(),
                         value,
                     })
                     .unwrap();


### PR DESCRIPTION
As discussed in #39 this PR implements the `Send` trait for `CLruCache`.

I am not sure if the tests are enough and relevant.

cc @xfix