### PR TITLE
Reset weight when clearing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,6 +421,7 @@ impl<K: Clone + Eq + Hash, V, S: BuildHasher, W: WeightScale<K, V>> CLruCache<K,
     pub fn clear(&mut self) {
         self.lookup.clear();
         self.storage.clear();
+        self.weight = 0;
     }
 
     /// Resizes the cache.


### PR DESCRIPTION
`clear` does not reset the weight as it should.