### PR TITLE
drop "MIT License" line from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-MIT License
-
 Copyright (c) 2020 Élie ROUDNINSKI (marmeladema) <xademax@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
I was importing this crate into Google's source control system. The automation at Google doesn't like the "MIT License" line at the beginning of the LICENSE-MIT file. AFAICT, the automation is correct in thinking that the line is not supposed to be there.

For reference, I've made the same change in gitoxide: https://github.com/Byron/gitoxide/pull/1097